### PR TITLE
fix: make it-all a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,13 +74,13 @@
     "@types/debug": "^4.1.5",
     "aegir": "^35.0.2",
     "interface-blockstore-tests": "^2.0.1",
-    "it-all": "^1.0.4",
     "util": "^0.12.4"
   },
   "dependencies": {
     "err-code": "^3.0.1",
     "interface-blockstore": "^2.0.2",
     "interface-store": "^2.0.1",
+    "it-all": "^1.0.4",
     "it-drain": "^1.0.4",
     "it-filter": "^1.0.2",
     "it-take": "^1.0.1",


### PR DESCRIPTION
`it-all` is directly used in src/base.js, so it should be a dependency, not a devDependency. This fixes an error that yarn pnp raises due to accessing an undeclared dependency.