### PR TITLE
fix: publish dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
       "sourceType": "module"
     }
   },
+  "publishConfig": {
+    "directory": "dist"
+  },
   "scripts": {
     "clean": "rimraf dist types",
     "prepare": "aegir build --no-bundle && cp -R types dist",


### PR DESCRIPTION
Adds the `publishConfig` field to package.json so we publish the correct directory.