### PR TITLE
fix: add errors for get and has failed

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -25,6 +25,11 @@ export function deleteFailedError (err?: Error): Error {
   return errCode(err, 'ERR_DELETE_FAILED')
 }
 
+export function hasFailedError (err?: Error): Error {
+  err = err ?? new Error('Has failed')
+  return errCode(err, 'ERR_HAS_FAILED')
+}
+
 export function notFoundError (err?: Error): Error {
   err = err ?? new Error('Not Found')
   return errCode(err, 'ERR_NOT_FOUND')

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,6 +15,11 @@ export function putFailedError (err?: Error): Error {
   return errCode(err, 'ERR_PUT_FAILED')
 }
 
+export function getFailedError (err?: Error): Error {
+  err = err ?? new Error('Get failed')
+  return errCode(err, 'ERR_GET_FAILED')
+}
+
 export function deleteFailedError (err?: Error): Error {
   err = err ?? new Error('Delete failed')
   return errCode(err, 'ERR_DELETE_FAILED')


### PR DESCRIPTION
For when getting a block fails, rather than when it wasn't found